### PR TITLE
fix: handle bsky profiles with no avatars

### DIFF
--- a/.changeset/brave-emus-wash.md
+++ b/.changeset/brave-emus-wash.md
@@ -1,0 +1,5 @@
+---
+"bluesky-comments-tag": patch
+---
+
+Handles Bluesky profiles with no avatars

--- a/packages/comments/src/BlueskyComments.js
+++ b/packages/comments/src/BlueskyComments.js
@@ -311,7 +311,7 @@ export class BlueskyComments extends HTMLElement {
       const createdAt = new Date(thread.post.record.createdAt);
       const createdAtFull = createdAt.toLocaleString();
       const createdAtAbbreviated = this.#getAbbreviatedTime(createdAt);
-      const avatarUrl = thread.post?.author?.avatar.replace(
+      const avatarUrl = thread.post?.author?.avatar?.replace(
         "/img/avatar/",
         "/img/avatar_thumbnail/",
       );


### PR DESCRIPTION
Occasionally, comment threads lack avatars for certain authors, and the bsky API response doesn’t include the `avatar` key for those authors. Consequently, an error message appears in the component. An example, at the time of writing:

Thread: https://bsky.app/profile/xkcd.com/post/3likd7zaws22d
Author: https://bsky.app/profile/dynamichron.bsky.social

This PR addresses these scenarios to ensure that comments can still be displayed instead of an error message.

By the way, thank you for creating this super useful web component!